### PR TITLE
Add battery configuration, fix compilation without Bluetooth and motion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+#OS auto-generated files
+.DS_Store
+
+#Python compiled
+*.pyc

--- a/controller/arduino/keyglove/application.cpp
+++ b/controller/arduino/keyglove/application.cpp
@@ -124,6 +124,7 @@ uint8_t my_kg_evt_motion_data(uint8_t index, uint8_t flags, uint8_t data_len, ui
  * expected communication response over UART, and all relevant module settings
  * have been requested and parsed.
  */
+#if (KG_HOSTIF & HG_HOSTIF_BT2_SPP) || (KG_HOSTIF & KG_HOSTIF_BT2_HID) || (KG_HOSTIF & KG_HOSTIF_BT2_RAWHID) || (KG_HOSTIF & KG_HOSTIF_BT2_IAP)
 uint8_t my_kg_evt_bluetooth_ready() {
     // set the Bluetooth mode to autocall paired devices
     kg_cmd_bluetooth_set_mode(KG_BLUETOOTH_MODE_AUTOCALL);
@@ -131,6 +132,7 @@ uint8_t my_kg_evt_bluetooth_ready() {
     // allow KGAPI event packet transmission
     return 0;
 }
+#endif
 
 /**
  * @brief Indicates that the touch sensor status has changed
@@ -189,6 +191,8 @@ void setup_application() {
     kg_evt_system_ready = my_kg_evt_system_ready;
     kg_evt_system_timer_tick = my_kg_evt_system_timer_tick;
     kg_evt_motion_data = my_kg_evt_motion_data;
+#if (KG_HOSTIF & HG_HOSTIF_BT2_SPP) || (KG_HOSTIF & KG_HOSTIF_BT2_HID) || (KG_HOSTIF & KG_HOSTIF_BT2_RAWHID) || (KG_HOSTIF & KG_HOSTIF_BT2_IAP)
     kg_evt_bluetooth_ready = my_kg_evt_bluetooth_ready;
+#endif
     kg_evt_touch_status = my_kg_evt_touch_status;
 }

--- a/controller/arduino/keyglove/application.h
+++ b/controller/arduino/keyglove/application.h
@@ -38,7 +38,9 @@ THE SOFTWARE.
 uint8_t my_kg_evt_system_ready();
 uint8_t my_kg_evt_system_timer_tick(uint8_t handle, uint32_t seconds, uint8_t subticks);
 uint8_t my_kg_evt_motion_data(uint8_t index, uint8_t flags, uint8_t data_len, uint8_t *data_data);
+#if (KG_HOSTIF & HG_HOSTIF_BT2_SPP) || (KG_HOSTIF & KG_HOSTIF_BT2_HID) || (KG_HOSTIF & KG_HOSTIF_BT2_RAWHID) || (KG_HOSTIF & KG_HOSTIF_BT2_IAP)
 uint8_t my_kg_evt_bluetooth_ready();
+#endif
 uint8_t my_kg_evt_touch_status(uint8_t status_len, uint8_t *status_data);
 
 void setup_application();

--- a/controller/arduino/keyglove/config.h
+++ b/controller/arduino/keyglove/config.h
@@ -218,6 +218,16 @@ THE SOFTWARE.
 //#define KG_MOTION           KG_MOTION_NONE
 #define KG_MOTION           KG_MOTION_MPU6050_HAND
 
+
+/**
+ * @brief Battery support selection
+ * @see KG_BATTERY_NONE
+ * @see KG_BATTERY_MAX17048
+ */
+//#define KG_BATTERY           KG_BATTERY_NONE
+#define KG_BATTERY           KG_BATTERY_MAX17048
+
+
 /**
  * @brief Feedback generator selection
  * @see KG_FEEBACK_BLINK

--- a/controller/arduino/keyglove/hardware.h
+++ b/controller/arduino/keyglove/hardware.h
@@ -109,6 +109,13 @@ THE SOFTWARE.
 
 
 
+/* Battery options.(defined in KG_BATTERY) */
+
+#define KG_BATTERY_NONE                 0x00        ///< No motion support
+#define KG_BATTERY_MAX17048             0x01        ///< Battery connected in I2C for status
+
+
+
 /* Sensory feedback. Multiple options may be enabled. (defined in KG_FEEDBACK) */
 
 #define KG_FEEDBACK_NONE                0x00        ///< No feedback support

--- a/controller/arduino/keyglove/support_motion.cpp
+++ b/controller/arduino/keyglove/support_motion.cpp
@@ -73,9 +73,11 @@ uint16_t kg_cmd_motion_set_mode(uint8_t index, uint8_t mode) {
         return KG_PROTOCOL_ERROR_PARAMETER_RANGE;
     } else {
         //motion_set_mode((motion_mode_t)mode);
-        if (index == 0) {
-            motion_set_mpu6050_hand_mode(mode);
-        }
+#if (KG_MOTION > 0)
+            if (index == 0) {
+                motion_set_mpu6050_hand_mode(mode);
+            }
+#endif
 
         // send kg_evt_feedback_vibrate_mode packet (if we aren't setting it from an API command)
         if (!inBinPacket) {

--- a/controller/arduino/keyglove/support_motion_mpu6050_hand.cpp
+++ b/controller/arduino/keyglove/support_motion_mpu6050_hand.cpp
@@ -45,6 +45,7 @@ THE SOFTWARE.
 #include "support_motion.h"
 //#include "support_motion_mpu6050_hand.h"    // <-- included by "support_motion.h"
 
+#if (KG_MOTION > 0)
 MPU6050 mpuHand = MPU6050(0x68);        ///< MPU-6050 motion sensor I2Cdevlib object
 bool mpuHandInterrupt;                  ///< Interrupt flag for motion data availability
 
@@ -192,3 +193,4 @@ void update_motion_mpu6050_hand() {
         send_keyglove_log(KG_LOG_LEVEL_VERBOSE, 10, F("ZEROMO INT"));
     }
 }
+#endif


### PR DESCRIPTION
The configuration for battery is required to avoid I2C blocking calls.

Disabling Bluetooth and motion requires a few defines.

After this commit, I succeeded compiling and running on a naked Teensy.

Note: I did modifications before the last 4 April 1st commits. There may be duplicates.
